### PR TITLE
Capitalization for Zwei/Drei

### DIFF
--- a/Ships.xml
+++ b/Ships.xml
@@ -1170,7 +1170,7 @@
   </Ship>
   <Ship>
     <JP-Name>Bismarck zwei</JP-Name>
-    <TR-Name>Bismarck zwei</TR-Name>
+    <TR-Name>Bismarck Zwei</TR-Name>
   </Ship>
   <Ship>
     <JP-Name>Z1</JP-Name>
@@ -1346,7 +1346,7 @@
   </Ship>
   <Ship>
     <JP-Name>Bismarck drei</JP-Name>
-    <TR-Name>Bismarck drei</TR-Name>
+    <TR-Name>Bismarck Drei</TR-Name>
   </Ship>
   <Ship>
     <JP-Name>隼鷹改二</JP-Name>


### PR DESCRIPTION
* Z1 and Z3 already use capitalized Zwei, while it's "zwei" and "drei" for Bismarck.
* Kai is capitalized, so should Zwei and Drei.

On the other hand, it's "zwei" and "drei" in-game, so if you want to change translations to that, then say so and I will --force push it in this PR.